### PR TITLE
Add lead-gen contact form, pain-point copy, social-proof scaffold

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "blyx-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 5173
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -105,9 +105,10 @@
       <div class="container hero-inner">
         <p class="eyebrow">Louisville · Residential + light commercial</p>
         <h1>Infrastructure that makes a space <em>work smarter.</em></h1>
-        <p class="hero-copy">We plan and install the connected systems behind modern spaces—reliable networks, considered access, and clear surveillance.</p>
+        <p class="hero-copy">Dead wifi zones. A front door you can't see. Cameras you can't trust when it matters. We plan and install the connected systems behind modern spaces—reliable networks, considered access, and clear surveillance.</p>
         <div class="hero-actions">
           <a class="button button-primary" href="#contact">Start a conversation</a>
+          <a class="phone-link" data-contact="phone" href="tel:+15025000105">(502) 500-0105</a>
           <a class="text-link" href="#services">Explore our focus <span aria-hidden="true">↓</span></a>
         </div>
       </div>
@@ -126,6 +127,7 @@
             <p class="service-number" aria-hidden="true">01</p>
             <div>
               <h3>Networking</h3>
+              <p class="service-pain">Dead zones, dropped calls, a router doing more than it should.</p>
               <p>Wired and wireless network planning, equipment placement, structured cabling, racks, and configuration shaped around the way your space is used.</p>
             </div>
             <p class="service-detail">Coverage · Capacity · Reliability</p>
@@ -134,6 +136,7 @@
             <p class="service-number" aria-hidden="true">02</p>
             <div>
               <h3>Access control</h3>
+              <p class="service-pain">A key that walks off. A door you can't see who's at.</p>
               <p>Entry systems designed around the people, doors, and permissions that matter—whether for a residence or a light-commercial property.</p>
             </div>
             <p class="service-detail">Entry · Permissions · Visibility</p>
@@ -142,6 +145,7 @@
             <p class="service-number" aria-hidden="true">03</p>
             <div>
               <h3>Surveillance</h3>
+              <p class="service-pain">Footage that's grainy, missing, or nowhere when you need it.</p>
               <p>Camera coverage planning, installation, recording, and remote viewing configured to provide useful visibility without unnecessary complexity.</p>
             </div>
             <p class="service-detail">Coverage · Recording · Access</p>
@@ -186,6 +190,21 @@
       </div>
     </section>
 
+    <!-- TODO: fill in once the current project closes and a testimonial is collected. -->
+    <section class="proof section">
+      <div class="container proof-grid">
+        <div class="proof-quote">
+          <p class="eyebrow">From the field</p>
+          <blockquote>Client testimonial goes here once the first project wraps.</blockquote>
+          <p class="proof-attribution">— Client name, neighborhood</p>
+        </div>
+        <div class="proof-photo">
+          <p class="proof-photo-placeholder" aria-hidden="true">Project photo</p>
+          <p class="proof-caption">One-line caption about the install.</p>
+        </div>
+      </div>
+    </section>
+
     <section class="contact section" id="contact">
       <div class="container contact-grid">
         <div>
@@ -193,8 +212,50 @@
           <h2>Tell us what your space needs to do better.</h2>
         </div>
         <div class="contact-panel">
-          <p>Share a little about the property, the system you’re considering, and where you are in the process.</p>
-          <a class="button button-light" data-contact="project-email" href="mailto:info@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">info@blyxventures.com</a>
+          <form class="contact-form" id="contact-form" novalidate>
+            <div class="form-row">
+              <label for="cf-name">Name</label>
+              <input id="cf-name" name="name" type="text" autocomplete="name" required>
+            </div>
+            <div class="form-row">
+              <label for="cf-email">Email</label>
+              <input id="cf-email" name="email" type="email" autocomplete="email" required>
+            </div>
+            <div class="form-row">
+              <label for="cf-phone">Phone <span class="optional">(optional)</span></label>
+              <input id="cf-phone" name="phone" type="tel" autocomplete="tel">
+            </div>
+            <div class="form-row form-row-split">
+              <div>
+                <label for="cf-property">Property type</label>
+                <select id="cf-property" name="propertyType">
+                  <option value="Residential">Residential</option>
+                  <option value="Light-commercial">Light-commercial</option>
+                </select>
+              </div>
+              <div>
+                <label for="cf-service">Service interest</label>
+                <select id="cf-service" name="service">
+                  <option value="Networking">Networking</option>
+                  <option value="Access control">Access control</option>
+                  <option value="Surveillance">Surveillance</option>
+                  <option value="Not sure yet">Not sure yet</option>
+                </select>
+              </div>
+            </div>
+            <div class="form-row">
+              <label for="cf-message">Tell us about the project</label>
+              <textarea id="cf-message" name="message" rows="4" required></textarea>
+            </div>
+            <div class="form-row form-honeypot" aria-hidden="true">
+              <label for="cf-company">Company</label>
+              <input id="cf-company" name="company" type="text" tabindex="-1" autocomplete="off">
+            </div>
+            <button class="button button-light" type="submit">Send inquiry</button>
+            <p class="form-status" id="contact-form-status" role="status" aria-live="polite"></p>
+          </form>
+          <p class="contact-alt">Prefer to reach out directly?</p>
+          <a class="text-link" data-contact="project-email" href="mailto:info@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">info@blyxventures.com</a>
           <a class="phone-link" data-contact="phone" href="tel:+15025000105">(502) 500-0105</a>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     "logo": "https://www.blyxventures.com/blyx-logo.png",
     "image": "https://www.blyxventures.com/og.png",
     "description": "We plan and install networking, access control, and surveillance systems for residential and light-commercial spaces in Louisville, KY and the surrounding metro area.",
-    "email": "info@blyxventures.com",
+    "email": "contact@blyxventures.com",
     "telephone": "+15025000105",
     "priceRange": "$$",
     "areaServed": {
@@ -95,7 +95,7 @@
         <a href="#approach">Approach</a>
         <a href="#contact">Contact</a>
       </nav>
-      <a class="header-cta" data-contact="header-email" href="mailto:info@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">Discuss a project</a>
+      <a class="header-cta" data-contact="header-email" href="mailto:contact@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">Discuss a project</a>
     </div>
   </header>
 
@@ -255,7 +255,7 @@
             <p class="form-status" id="contact-form-status" role="status" aria-live="polite"></p>
           </form>
           <p class="contact-alt">Prefer to reach out directly?</p>
-          <a class="text-link" data-contact="project-email" href="mailto:info@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">info@blyxventures.com</a>
+          <a class="text-link" data-contact="project-email" href="mailto:contact@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">contact@blyxventures.com</a>
           <a class="phone-link" data-contact="phone" href="tel:+15025000105">(502) 500-0105</a>
         </div>
       </div>

--- a/privacy.html
+++ b/privacy.html
@@ -41,7 +41,7 @@
         </section>
         <section>
           <h2>Information we collect</h2>
-          <p>When you contact us, we receive the information you choose to provide, which may include your name, email address, phone number, project location, and details about your inquiry.</p>
+          <p>When you contact us—through our contact form, by email, or by phone—we receive the information you choose to provide, which may include your name, email address, phone number, property type, and details about your inquiry. Contact form submissions are processed through Google Apps Script and delivered to our inbox.</p>
           <p>We also use Google Analytics to understand general website activity. This may involve device, browser, usage, and approximate location information collected through cookies or similar technologies.</p>
         </section>
         <section>

--- a/privacy.html
+++ b/privacy.html
@@ -23,7 +23,7 @@
         <a href="index.html#approach">Approach</a>
         <a href="index.html#contact">Contact</a>
       </nav>
-      <a class="header-cta" data-contact="header-email" href="mailto:info@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">Discuss a project</a>
+      <a class="header-cta" data-contact="header-email" href="mailto:contact@blyxventures.com?subject=Project%20inquiry%20for%20Blyx">Discuss a project</a>
     </div>
   </header>
 
@@ -62,7 +62,7 @@
         </section>
         <section>
           <h2>Contact</h2>
-          <p>For privacy questions or requests, email <a href="mailto:info@blyxventures.com">info@blyxventures.com</a>.</p>
+          <p>For privacy questions or requests, email <a href="mailto:contact@blyxventures.com">contact@blyxventures.com</a>.</p>
         </section>
       </div>
     </div>

--- a/scripts/contact-form.gs
+++ b/scripts/contact-form.gs
@@ -2,7 +2,7 @@
  * Blyx contact form backend.
  *
  * Setup:
- * 1. Go to script.google.com (signed in as info@blyxventures.com or a Workspace account
+ * 1. Go to script.google.com (signed in as contact@blyxventures.com or a Workspace account
  *    that can send mail as that address), create a new project, paste this file in.
  * 2. Deploy > New deployment > type "Web app".
  *    - Execute as: Me
@@ -10,7 +10,7 @@
  * 3. Copy the resulting /exec URL and set it as CONTACT_FORM_ENDPOINT in src/main.js.
  */
 
-const NOTIFY_EMAIL = 'info@blyxventures.com';
+const NOTIFY_EMAIL = 'contact@blyxventures.com';
 
 function doPost(e) {
   const data = JSON.parse(e.postData.contents);

--- a/scripts/contact-form.gs
+++ b/scripts/contact-form.gs
@@ -1,0 +1,56 @@
+/**
+ * Blyx contact form backend.
+ *
+ * Setup:
+ * 1. Go to script.google.com (signed in as info@blyxventures.com or a Workspace account
+ *    that can send mail as that address), create a new project, paste this file in.
+ * 2. Deploy > New deployment > type "Web app".
+ *    - Execute as: Me
+ *    - Who has access: Anyone
+ * 3. Copy the resulting /exec URL and set it as CONTACT_FORM_ENDPOINT in src/main.js.
+ */
+
+const NOTIFY_EMAIL = 'info@blyxventures.com';
+
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+
+  // Honeypot: bots fill hidden fields, real users never see this input.
+  if (data.company) {
+    return jsonResponse({ ok: true });
+  }
+
+  const name = (data.name || '').trim();
+  const email = (data.email || '').trim();
+  const message = (data.message || '').trim();
+
+  if (!name || !email || !message) {
+    return jsonResponse({ ok: false, error: 'missing_required_fields' });
+  }
+
+  const lines = [
+    `Name: ${name}`,
+    `Email: ${email}`,
+    `Phone: ${data.phone || '—'}`,
+    `Property type: ${data.propertyType || '—'}`,
+    `Service interest: ${data.service || '—'}`,
+    '',
+    'Message:',
+    message,
+  ];
+
+  MailApp.sendEmail({
+    to: NOTIFY_EMAIL,
+    replyTo: email,
+    subject: `Project inquiry from ${name}`,
+    body: lines.join('\n'),
+  });
+
+  return jsonResponse({ ok: true });
+}
+
+function jsonResponse(body) {
+  return ContentService
+    .createTextOutput(JSON.stringify(body))
+    .setMimeType(ContentService.MimeType.JSON);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -8,3 +8,51 @@ document.querySelectorAll('[data-contact]').forEach((link) => {
     trackContactIntent(link.dataset.contact);
   });
 });
+
+// scripts/contact-form.gs deployed as a Google Apps Script Web App.
+const CONTACT_FORM_ENDPOINT = 'https://script.google.com/macros/s/AKfycbxNJ5Vf4C3fxlfj13_kV00A0KRA6x45Em0TdnV_oQfvLRhrqXqGHeaqE8ZSjzlxHRqadA/exec';
+
+const contactForm = document.getElementById('contact-form');
+const contactFormStatus = document.getElementById('contact-form-status');
+
+if (contactForm) {
+  contactForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    if (!CONTACT_FORM_ENDPOINT) {
+      setFormStatus('error', "Form isn't connected yet — email us directly at info@blyxventures.com.");
+      return;
+    }
+
+    const submitButton = contactForm.querySelector('button[type="submit"]');
+    const payload = Object.fromEntries(new FormData(contactForm).entries());
+
+    submitButton.disabled = true;
+    setFormStatus('pending', 'Sending…');
+
+    try {
+      // Apps Script web apps don't handle CORS preflight, so this is sent as a
+      // simple, unreadable ("no-cors") request — a resolved fetch is the only
+      // success signal available.
+      await fetch(CONTACT_FORM_ENDPOINT, {
+        method: 'POST',
+        mode: 'no-cors',
+        headers: { 'Content-Type': 'text/plain;charset=utf-8' },
+        body: JSON.stringify(payload),
+      });
+      contactForm.reset();
+      setFormStatus('success', "Thanks — we'll be in touch soon.");
+      trackContactIntent('contact-form');
+    } catch {
+      setFormStatus('error', "Something went wrong — email us directly at info@blyxventures.com.");
+    } finally {
+      submitButton.disabled = false;
+    }
+  });
+}
+
+function setFormStatus(state, message) {
+  if (!contactFormStatus) return;
+  contactFormStatus.textContent = message;
+  contactFormStatus.dataset.state = state;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -20,7 +20,7 @@ if (contactForm) {
     event.preventDefault();
 
     if (!CONTACT_FORM_ENDPOINT) {
-      setFormStatus('error', "Form isn't connected yet — email us directly at info@blyxventures.com.");
+      setFormStatus('error', "Form isn't connected yet — email us directly at contact@blyxventures.com.");
       return;
     }
 
@@ -44,7 +44,7 @@ if (contactForm) {
       setFormStatus('success', "Thanks — we'll be in touch soon.");
       trackContactIntent('contact-form');
     } catch {
-      setFormStatus('error', "Something went wrong — email us directly at info@blyxventures.com.");
+      setFormStatus('error', "Something went wrong — email us directly at contact@blyxventures.com.");
     } finally {
       submitButton.disabled = false;
     }

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -56,6 +56,8 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
 .hero-inner { position: relative; padding-top: 7rem; padding-bottom: 5rem; }
 .hero-copy { max-width: 650px; margin: 0 0 2.5rem; color: #505753; font-size: clamp(1.1rem, 2vw, 1.35rem); }
 .hero-actions { display: flex; align-items: center; gap: 2rem; }
+.hero-actions .phone-link { margin-top: 0; color: #3f4642; font-size: .92rem; font-weight: 600; }
+.hero-actions .phone-link:hover, .hero-actions .phone-link:focus-visible { color: var(--green-dark); text-decoration: underline; }
 .button { display: inline-flex; align-items: center; justify-content: center; min-height: 54px; padding: .9rem 1.4rem; border: 1px solid transparent; text-decoration: none; font-size: .92rem; font-weight: 600; transition: background-color .2s ease, color .2s ease, border-color .2s ease; }
 .button-primary { background: var(--dark); color: var(--white); }
 .button-primary:hover, .button-primary:focus-visible { background: var(--green-dark); }
@@ -72,6 +74,7 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
 .service-item h3 { font-size: clamp(1.65rem, 3vw, 2.2rem); }
 .service-item div p { max-width: 630px; margin: 0; color: var(--muted); }
 .service-detail { margin: .35rem 0 0; color: #717873; font-size: .77rem; letter-spacing: .07em; text-transform: uppercase; }
+.service-pain { margin: 0 0 .5rem; color: var(--green-dark); font-size: .82rem; font-weight: 600; }
 
 .statement { background: var(--green-dark); color: var(--white); }
 .statement .eyebrow { color: #bfe9d8; }
@@ -93,6 +96,14 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
 .fit-copy { padding-top: 3.2rem; color: var(--muted); font-size: 1.06rem; }
 .fit-copy p { margin: 0 0 1.5rem; }
 
+.proof { background: var(--white); }
+.proof-grid { display: grid; grid-template-columns: 1.3fr 1fr; gap: clamp(2rem, 6vw, 4rem); align-items: center; padding-block: clamp(3rem, 6vw, 5rem); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.proof-quote blockquote { margin: 0 0 1rem; font-size: clamp(1.5rem, 3vw, 2.1rem); line-height: 1.3; color: var(--ink); }
+.proof-attribution { margin: 0; color: var(--muted); font-size: .9rem; }
+.proof-photo { padding: 2.5rem; border: 1px dashed var(--line); text-align: center; }
+.proof-photo-placeholder { margin: 0 0 .75rem; color: var(--muted); font-size: .85rem; letter-spacing: .07em; text-transform: uppercase; }
+.proof-caption { margin: 0; color: var(--muted); font-size: .85rem; }
+
 .contact { background: var(--dark); color: var(--white); }
 .contact .eyebrow { color: #a9dfca; }
 .contact-grid { display: grid; grid-template-columns: 1.1fr .65fr; gap: clamp(3rem, 10vw, 9rem); align-items: end; }
@@ -103,6 +114,22 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
 .button-light:hover, .button-light:focus-visible { background: #dff4eb; }
 .phone-link { display: block; width: fit-content; margin-top: 1.25rem; color: #cbd1ce; }
 .phone-link:hover, .phone-link:focus-visible { color: var(--white); text-decoration: underline; }
+
+.contact-form { display: grid; gap: 1.25rem; margin-bottom: 1.5rem; }
+.contact-form .form-row { display: flex; flex-direction: column; gap: .4rem; }
+.contact-form .form-row-split { display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem; }
+.contact-form .form-row-split > div { display: flex; flex-direction: column; gap: .4rem; }
+.contact-form label { font-size: .82rem; color: #c5cbc8; }
+.contact-form .optional { color: #8b948f; font-weight: 400; }
+.contact-form input, .contact-form select, .contact-form textarea { padding: .75rem .9rem; border: 1px solid #52605a; background: #1f2a25; color: var(--white); font: inherit; font-size: .95rem; }
+.contact-form textarea { resize: vertical; }
+.contact-form select { appearance: auto; }
+.contact-form .form-honeypot { position: absolute; left: -9999px; width: 1px; height: 1px; overflow: hidden; }
+.contact-form button[type="submit"] { align-self: start; margin-top: .25rem; }
+.form-status { min-height: 1.2rem; margin: .75rem 0 0; font-size: .88rem; }
+.form-status[data-state="success"] { color: #bfe9d8; }
+.form-status[data-state="error"] { color: var(--white); font-weight: 600; }
+.contact-panel .contact-alt { margin-bottom: .75rem; }
 
 .site-footer { padding-block: 3rem; background: #121815; color: #9fa8a3; font-size: .8rem; }
 .footer-grid { display: grid; grid-template-columns: 180px 1fr auto; gap: 2rem; align-items: center; }
@@ -141,7 +168,7 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
   .process-list { grid-template-columns: repeat(2, 1fr); }
   .process-list li:nth-child(2) { border-right: 0; }
   .process-list li:nth-child(n+3) { border-top: 1px solid #c9cbc4; }
-  .fit-grid, .contact-grid, .legal-grid { grid-template-columns: 1fr; }
+  .fit-grid, .contact-grid, .legal-grid, .proof-grid { grid-template-columns: 1fr; }
   .fit-copy { max-width: 680px; padding-top: 0; }
   .contact-panel { max-width: 560px; }
   .footer-grid { grid-template-columns: 1fr auto; }
@@ -155,6 +182,8 @@ h3 { margin-bottom: .75rem; font-size: 1.45rem; line-height: 1.2; }
   .hero-grid { width: 86vw; right: -35%; top: 28%; opacity: .4; }
   .hero-inner { padding-top: 5rem; padding-bottom: 3rem; }
   .hero-actions { align-items: flex-start; flex-direction: column; gap: 1.4rem; }
+  .contact-form .form-row-split { grid-template-columns: 1fr; }
+  .proof-photo { padding: 1.75rem; }
   .service-item { padding-block: 2.25rem; grid-template-columns: 1fr; gap: .75rem; }
   .service-detail { grid-column: 1; }
   .process-list { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- Replace the mailto-only CTA with a real contact form (name/email/phone/property type/service interest/message), backed by a Google Apps Script Web App that emails contact@blyxventures.com
- Lead hero and services copy with client pain points instead of capability-first framing
- Add a social-proof section scaffold (testimonial + project photo placeholders) ready to fill in once the first project completes
- Add a phone CTA alongside the primary hero CTA
- No changes to color palette, typography, or existing layout patterns — new markup reuses existing CSS vars and component styles

## Test plan
- [x] `npm run check` production build passes
- [x] Verified via browser accessibility tree that form, proof section, and copy changes render correctly
- [x] Submitted a live test inquiry through the deployed Apps Script endpoint and confirmed `doPost` executes (curl + browser test)
- [ ] Confirm `contact@blyxventures.com` mailbox/alias is set up in Workspace and a live form submission is delivered

Manual step still required: the Apps Script deployment (`scripts/contact-form.gs`) must be updated with the `contact@` address and redeployed as a new version for `NOTIFY_EMAIL` to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)